### PR TITLE
Dockerfile: Add config directory as volume and add mod_auth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,10 @@
 
 FROM alpine
 
-RUN apk add --update lighttpd \
- && rm -rf /var/cache/apk/*
+RUN apk add --update --no-cache \
+	lighttpd \
+	lighttpd-mod_auth \
+  && rm -rf /var/cache/apk/*
 
 ## workaround for bug preventing sync between VirtualBox and host
 # http://serverfault.com/questions/240038/lighttpd-broken-when-serving-from-virtualbox-shared-folder
@@ -12,5 +14,6 @@ RUN echo server.network-backend = \"writev\" >> /etc/lighttpd/lighttpd.conf
 EXPOSE 80
 
 VOLUME /var/www/localhost
+VOLUME /etc/lighttpd
 
 CMD ["lighttpd", "-D", "-f", "/etc/lighttpd/lighttpd.conf"]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ In the instructions that follow, replace `<home-directory>` with the path of the
 
 ### Start a container with Docker
 
-	$ sudo docker run --rm -t -v <home-directory>:/var/www/localhost/htdocs -p <http-port>:80 sebp/lighttpd
+	$ sudo docker run --rm -t -v <home-directory>:/var/www/localhost/htdocs -v <config-directory>:/etc/lighttpd -p <http-port>:80 sebp/lighttpd
 
 ### Start a container with Docker Compose
 
@@ -28,6 +28,7 @@ Add the following lines in an existing or a new `docker-compose.yml` file:
 	  image: sebp/lighttpd
 	  volumes:
 	    - <home-directory>:/var/www/localhost/htdocs
+	    - <config-directory>:/etc/lighttpd
 	  ports:
 	    - "<http-port>:80"
 


### PR DESCRIPTION
Allow to modify /etc/lighttpd on the host by exposing it as
a volume; this allows for use in testing/on-off environments
where you don't want to bake a config into a docker image.

Also add lighttpd-mod_auth.

Signed-off-by: Daniel Dickinson <docker@cshore.thecshore.com>