### PR TITLE
feat: add stderr and stdout error and access logging for docker logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,11 @@ RUN apk add --update --no-cache \
 RUN echo server.network-backend = \"writev\" >> /etc/lighttpd/lighttpd.conf
 
 COPY etc/lighttpd/* /etc/lighttpd/
+COPY start.sh /usr/local/bin/
 
 EXPOSE 80
 
 VOLUME /var/www/localhost
 VOLUME /etc/lighttpd
 
-CMD ["lighttpd", "-D", "-f", "/etc/lighttpd/lighttpd.conf"]
+CMD ["start.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@
 # $ sudo docker exec -it lighttpddocker_lighttpd_1 ash
 
 lighttpd:
+    container_name: lighttpd
     build: .
+    restart: always
     ports:
         - "8001:80" # for testing purposes, (un)comment as required

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# this launcher script tails the access and error logs
+# to the stdout and stderr, so that `docker logs -f lighthttpd` works.
+
+tail -F /var/log/lighttpd/access.log 2>/dev/null &
+tail -F /var/log/lighttpd/error.log 2>/dev/null 1>&2 &
+lighttpd -D -f /etc/lighttpd/lighttpd.conf


### PR DESCRIPTION
This patch will output /var/log/lighttpd/access.log and /var/log/lighttpd/error.log (if exist) to stdout and stderr pipes, so that the command `docker logs -f lighttpd` works as expected.

It also adds a restart directive to docker-compose.yml and sets a meaningful containtername.