### PR TITLE
Run lighttpd as "pid 1" to shutdown properly

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -5,4 +5,4 @@
 
 tail -F /var/log/lighttpd/access.log 2>/dev/null &
 tail -F /var/log/lighttpd/error.log 2>/dev/null 1>&2 &
-lighttpd -D -f /etc/lighttpd/lighttpd.conf
+exec lighttpd -D -f /etc/lighttpd/lighttpd.conf


### PR DESCRIPTION
Currently "docker stop" sends signals to sh which isn't a process manager and doesn't pass signals to spawned processes. Docker forcibly terminates the processes after 10 seconds.

This allows the lighttpd process to receive signals like "docker stop" and immediately shutdown gracefully.