### PR TITLE
Only log outside the container, not inside

### DIFF
--- a/etc/lighttpd/lighttpd.conf
+++ b/etc/lighttpd/lighttpd.conf
@@ -55,7 +55,7 @@ server.groupname     = "lighttpd"
 server.document-root = var.basedir + "/htdocs"
 server.pid-file      = "/run/lighttpd.pid"
 
-server.errorlog      = var.logdir  + "/error.log"
+server.errorlog      = "/dev/pts/0"
 # log errors to syslog instead
 #   server.errorlog-use-syslog = "enable"
 
@@ -106,7 +106,7 @@ static-file.exclude-extensions = (".php", ".pl", ".cgi", ".fcgi")
 # }}}
 
 # {{{ mod_accesslog
-accesslog.filename   = var.logdir + "/access.log"
+accesslog.filename   = "/dev/pts/0"
 # }}}
 
 # {{{ mod_dirlisting

--- a/start.sh
+++ b/start.sh
@@ -1,8 +1,4 @@
 #!/bin/sh
 
-# this launcher script tails the access and error logs
-# to the stdout and stderr, so that `docker logs -f lighthttpd` works.
-
-tail -F /var/log/lighttpd/access.log 2>/dev/null &
-tail -F /var/log/lighttpd/error.log 2>/dev/null 1>&2 &
+chmod a+w /dev/pts/0
 lighttpd -D -f /etc/lighttpd/lighttpd.conf


### PR DESCRIPTION
Currently the container writes logs to /var/log/lighttpd/ and can consume a lot of disk space over time as there is no logrotate process scheduled to run.

This patch writes server and traffic logs to stdout only to avoid consuming disk space.