### PR TITLE
[Security] update lighttpd to 1.4.61-r1

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -33,4 +33,4 @@ jobs:
           docker buildx build \
             --platform linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6 \
             --push . \
-            -t sebp/lighttpd:latest -t sebp/lighttpd:1.4.59-r0
+            -t sebp/lighttpd:latest -t sebp/lighttpd:1.4.61-r1

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM alpine
 
-ENV LIGHTTPD_VERSION=1.4.59-r0
+ENV LIGHTTPD_VERSION=1.4.61-r1
 
 RUN apk add --update --no-cache \
 	lighttpd=${LIGHTTPD_VERSION} \


### PR DESCRIPTION
This PR updates lighttpd to 1.4.61-r1

Additionally, it fixes 11 vulnerabilities that originate from an outdated busybox version.

Vulnerabilities (selection): CVE-2021-42378, CVE-2021-42375, CVE-2021-42374